### PR TITLE
Feat/#82 회원정보 조회 기능, user test 추가, 회원가입 필드에 queryDSL으로 변경, orderStatus 테스트 코드 추가

### DIFF
--- a/src/main/java/app/domain/order/model/dto/request/UpdateOrderStatusRequest.java
+++ b/src/main/java/app/domain/order/model/dto/request/UpdateOrderStatusRequest.java
@@ -1,9 +1,13 @@
 package app.domain.order.model.dto.request;
 
 import app.domain.order.model.entity.enums.OrderStatus;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.Setter;
 
+@Setter
 @Getter
 public class UpdateOrderStatusRequest {
+	@NotNull
 	private OrderStatus newStatus;
 }

--- a/src/main/java/app/domain/user/UserController.java
+++ b/src/main/java/app/domain/user/UserController.java
@@ -1,6 +1,7 @@
 package app.domain.user;
 
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import app.domain.user.model.dto.request.CreateUserRequest;
 import app.domain.user.model.dto.request.LoginRequest;
 import app.domain.user.model.dto.response.CreateUserResponse;
+import app.domain.user.model.dto.response.GetUserInfoResponse;
 import app.domain.user.model.dto.response.LoginResponse;
 import app.domain.user.status.UserSuccessStatus;
 import app.global.apiPayload.ApiResponse;
@@ -51,5 +53,12 @@ public class UserController {
 	public ApiResponse<Void> withdraw() {
 		userService.withdrawMembership();
 		return ApiResponse.onSuccess(UserSuccessStatus.WITHDRAW_SUCCESS, null);
+	}
+
+	@GetMapping("/info")
+	@Operation(summary = "회원 정보 조회 API", description = "현재 로그인된 사용자의 정보를 조회합니다.")
+	public ApiResponse<GetUserInfoResponse> getUserInfo() {
+		GetUserInfoResponse response = userService.getUserInfo();
+		return ApiResponse.onSuccess(UserSuccessStatus.USER_PROFILE_FETCHED, response);
 	}
 }

--- a/src/main/java/app/domain/user/UserService.java
+++ b/src/main/java/app/domain/user/UserService.java
@@ -16,9 +16,11 @@ import app.domain.user.model.UserRepository;
 import app.domain.user.model.dto.request.CreateUserRequest;
 import app.domain.user.model.dto.request.LoginRequest;
 import app.domain.user.model.dto.response.CreateUserResponse;
+import app.domain.user.model.dto.response.GetUserInfoResponse;
 import app.domain.user.model.dto.response.LoginResponse;
 import app.domain.user.model.entity.User;
 import app.domain.user.status.UserErrorStatus;
+import app.global.SecurityUtil;
 import app.global.apiPayload.code.status.ErrorStatus;
 import app.global.apiPayload.exception.GeneralException;
 import app.global.jwt.JwtTokenProvider;
@@ -36,6 +38,7 @@ public class UserService {
 	private final PasswordEncoder passwordEncoder;
 	private final JwtTokenProvider jwtTokenProvider;
 	private final RedisTemplate<String, String> redisTemplate;
+	private final SecurityUtil securityUtil;
 	private static final String REFRESH_TOKEN_PREFIX = "RT:";
 	private static final String BLACKLIST_PREFIX = "BL:";
 
@@ -127,6 +130,12 @@ public class UserService {
 		userRepository.delete(user);
 
 		logout();
+	}
+
+	@Transactional
+	GetUserInfoResponse getUserInfo() {
+		User currentUser = securityUtil.getCurrentUser();
+		return GetUserInfoResponse.from(currentUser);
 	}
 
 	/**

--- a/src/main/java/app/domain/user/UserService.java
+++ b/src/main/java/app/domain/user/UserService.java
@@ -150,10 +150,6 @@ public class UserService {
 		return GetUserInfoResponse.from(currentUser);
 	}
 
-	/**
-	 * 사용자의 고유 필드(아이디, 이메일, 닉네임, 전화번호) 중복 여부 검사 - 회원가입에서만 사용
-	 * @param createUserRequest 회원가입 요청 DTO
-	 */
 	private void validateUserUniqueness(CreateUserRequest createUserRequest) {
 		userRepository.findFirstByUniqueFields(
 			createUserRequest.getUsername(),

--- a/src/main/java/app/domain/user/model/UserRepository.java
+++ b/src/main/java/app/domain/user/model/UserRepository.java
@@ -5,29 +5,17 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import app.domain.user.model.entity.User;
 import app.domain.user.model.entity.enums.UserRole;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
 
 	Optional<User> findByUsername(String userName);
 
 	Optional<User> findByUserId(Long userId);
 
 	Page<User> findAllByUserRole(UserRole role, Pageable pageable);
-
-	// TODO : QUERYDSL로 수정 필요
-	@Query("SELECT u FROM User u WHERE u.username = :username OR u.email = :email OR u.nickname = :nickname OR u.phoneNumber = :phoneNumber")
-	Optional<User> findFirstByUniqueFields(
-		@Param("username") String username,
-		@Param("email") String email,
-		@Param("nickname") String nickname,
-		@Param("phoneNumber") String phoneNumber
-	);
-
 }

--- a/src/main/java/app/domain/user/model/UserRepositoryCustom.java
+++ b/src/main/java/app/domain/user/model/UserRepositoryCustom.java
@@ -1,0 +1,9 @@
+package app.domain.user.model;
+
+import java.util.Optional;
+
+import app.domain.user.model.entity.User;
+
+public interface UserRepositoryCustom {
+	Optional<User> findFirstByUniqueFields(String username, String email, String nickname, String phoneNumber);
+}

--- a/src/main/java/app/domain/user/model/UserRepositoryCustomImpl.java
+++ b/src/main/java/app/domain/user/model/UserRepositoryCustomImpl.java
@@ -1,0 +1,32 @@
+package app.domain.user.model;
+
+import static app.domain.user.model.entity.QUser.*;
+
+import java.util.Optional;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import app.domain.user.model.entity.User;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class UserRepositoryCustomImpl implements UserRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Optional<User> findFirstByUniqueFields(String username, String email, String nickname, String phoneNumber) {
+		BooleanExpression predicate = user.username.eq(username)
+			.or(user.email.eq(email))
+			.or(user.nickname.eq(nickname))
+			.or(user.phoneNumber.eq(phoneNumber));
+
+		User foundUser = queryFactory
+			.selectFrom(user)
+			.where(predicate)
+			.fetchFirst();
+
+		return Optional.ofNullable(foundUser);
+	}
+}

--- a/src/main/java/app/domain/user/model/dto/response/GetUserInfoResponse.java
+++ b/src/main/java/app/domain/user/model/dto/response/GetUserInfoResponse.java
@@ -1,0 +1,31 @@
+package app.domain.user.model.dto.response;
+
+import app.domain.user.model.entity.User;
+import app.domain.user.model.entity.enums.UserRole;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetUserInfoResponse {
+
+	private Long userId;
+	private String username;
+	private String email;
+	private String nickname;
+	private String realName;
+	private String phoneNumber;
+	private UserRole userRole;
+
+	public static GetUserInfoResponse from(User user) {
+		return GetUserInfoResponse.builder()
+			.userId(user.getUserId())
+			.username(user.getUsername())
+			.email(user.getEmail())
+			.nickname(user.getNickname())
+			.realName(user.getRealName())
+			.phoneNumber(user.getPhoneNumber())
+			.userRole(user.getUserRole())
+			.build();
+	}
+}

--- a/src/main/java/app/domain/user/status/UserErrorStatus.java
+++ b/src/main/java/app/domain/user/status/UserErrorStatus.java
@@ -11,14 +11,14 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum UserErrorStatus implements BaseCode {
 
-	// 인증 관련
 	INVALID_PASSWORD(HttpStatus.FORBIDDEN, "AUTH_001", "비밀번호가 일치하지 않습니다."),
 
-	// User 관련
 	USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER001", "이미 존재하는 유저입니다."),
 	EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER002", "이미 사용 중인 이메일입니다."),
 	NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER003", "이미 사용 중인 닉네임입니다."),
-	PHONE_NUMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER004", "이미 사용 중인 전화번호입니다.");
+	PHONE_NUMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER004", "이미 사용 중인 전화번호입니다."),
+
+	AUTHENTICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "USER005", "인증 정보를 찾을 수 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/app/domain/user/status/UserSuccessStatus.java
+++ b/src/main/java/app/domain/user/status/UserSuccessStatus.java
@@ -11,11 +11,11 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum UserSuccessStatus implements BaseCode {
 
-	// User
 	USER_CREATED(HttpStatus.CREATED, "USER201", "사용자 생성이 성공했습니다."),
 	LOGIN_SUCCESS(HttpStatus.OK, "USER202", "로그인에 성공했습니다."),
 	LOGOUT_SUCCESS(HttpStatus.OK, "USER203", "로그아웃에 성공했습니다."),
-	WITHDRAW_SUCCESS(HttpStatus.OK, "USER204", "회원 탈퇴가 성공적으로 처리되었습니다.");
+	WITHDRAW_SUCCESS(HttpStatus.OK, "USER204", "회원 탈퇴가 성공적으로 처리되었습니다."),
+	USER_PROFILE_FETCHED(HttpStatus.OK, "USER205", "회원 정보 조회에 성공했습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/test/java/app/domain/user/UserServiceGetUserInfoTest.java
+++ b/src/test/java/app/domain/user/UserServiceGetUserInfoTest.java
@@ -1,0 +1,110 @@
+package app.domain.user;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataAccessException;
+
+import app.domain.user.model.dto.response.GetUserInfoResponse;
+import app.domain.user.model.entity.User;
+import app.domain.user.model.entity.enums.UserRole;
+import app.global.SecurityUtil;
+import app.global.apiPayload.code.status.ErrorStatus;
+import app.global.apiPayload.exception.GeneralException;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserService.getUserInfo 테스트")
+class UserServiceGetUserInfoTest {
+
+	@InjectMocks
+	private UserService userService;
+
+	@Mock
+	private SecurityUtil securityUtil;
+
+	@Nested
+	@DisplayName("성공 케이스")
+	class SuccessCase {
+		@Test
+		@DisplayName("현재 로그인된 사용자의 정보를 성공적으로 조회한다.")
+		void getUserInfo_Success() {
+			// given
+			User mockUser = User.builder()
+				.userId(1L)
+				.username("testuser")
+				.email("test@example.com")
+				.nickname("testnick")
+				.realName("김테스트")
+				.phoneNumber("01012345678")
+				.userRole(UserRole.CUSTOMER)
+				.build();
+
+			given(securityUtil.getCurrentUser()).willReturn(mockUser);
+
+			// when
+			GetUserInfoResponse response = userService.getUserInfo();
+
+			// then
+			assertThat(response).isNotNull();
+			assertThat(response.getUserId()).isEqualTo(mockUser.getUserId());
+			assertThat(response.getUsername()).isEqualTo(mockUser.getUsername());
+			assertThat(response.getEmail()).isEqualTo(mockUser.getEmail());
+			assertThat(response.getNickname()).isEqualTo(mockUser.getNickname());
+			assertThat(response.getRealName()).isEqualTo(mockUser.getRealName());
+			assertThat(response.getPhoneNumber()).isEqualTo(mockUser.getPhoneNumber());
+			assertThat(response.getUserRole()).isEqualTo(mockUser.getUserRole());
+
+			then(securityUtil).should().getCurrentUser();
+		}
+	}
+
+	@Nested
+	@DisplayName("실패 케이스")
+	class FailureCase {
+		@Test
+		@DisplayName("인증 정보가 없어 사용자를 찾을 수 없을 때, GeneralException(_UNAUTHORIZED)을 던진다.")
+		void getUserInfo_Fail_Unauthorized() {
+			// given
+			given(securityUtil.getCurrentUser()).willThrow(new GeneralException(ErrorStatus._UNAUTHORIZED));
+
+			// when & then
+			assertThatThrownBy(() -> userService.getUserInfo())
+				.isInstanceOf(GeneralException.class)
+				.extracting("code")
+				.isEqualTo(ErrorStatus._UNAUTHORIZED);
+		}
+
+		@Test
+		@DisplayName("토큰은 유효하지만 DB에 해당 사용자가 없을 때, GeneralException(USER_NOT_FOUND)을 던진다.")
+		void getUserInfo_Fail_UserNotFoundInDb() {
+			// given
+			given(securityUtil.getCurrentUser()).willThrow(new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+			// when & then
+			assertThatThrownBy(() -> userService.getUserInfo())
+				.isInstanceOf(GeneralException.class)
+				.extracting("code")
+				.isEqualTo(ErrorStatus.USER_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("DB 조회 중 예외 발생 시, 해당 예외가 그대로 전파된다.")
+		void getUserInfo_Fail_DatabaseError() {
+			// given
+			given(securityUtil.getCurrentUser()).willThrow(new DataAccessException("DB connection failed") {
+			});
+
+			// when & then
+			assertThatThrownBy(() -> userService.getUserInfo())
+				.isInstanceOf(DataAccessException.class)
+				.hasMessage("DB connection failed");
+		}
+	}
+}

--- a/src/test/java/app/global/config/TestJpaConfig.java
+++ b/src/test/java/app/global/config/TestJpaConfig.java
@@ -1,0 +1,18 @@
+package app.global.config;
+
+import java.util.Optional;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@TestConfiguration
+@EnableJpaAuditing
+public class TestJpaConfig {
+
+	@Bean
+	public AuditorAware<Long> auditorProvider() {
+		return () -> Optional.of(1L);
+	}
+}

--- a/src/test/java/app/unit/domain/order/OrderControllerUpdateOrderStatusTest.java
+++ b/src/test/java/app/unit/domain/order/OrderControllerUpdateOrderStatusTest.java
@@ -1,0 +1,131 @@
+package app.unit.domain.order;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import app.domain.order.OrderController;
+import app.domain.order.model.dto.request.UpdateOrderStatusRequest;
+import app.domain.order.model.dto.response.UpdateOrderStatusResponse;
+import app.domain.order.model.entity.enums.OrderStatus;
+import app.domain.order.service.OrderService;
+import app.domain.order.status.OrderErrorStatus;
+import app.domain.order.status.OrderSuccessStatus;
+import app.global.apiPayload.code.status.ErrorStatus;
+import app.global.apiPayload.exception.GeneralException;
+import app.global.config.MockSecurityConfig;
+
+@WebMvcTest(controllers = OrderController.class)
+@Import(MockSecurityConfig.class)
+@AutoConfigureMockMvc(addFilters = false)
+@DisplayName("OrderController 테스트")
+class OrderControllerUpdateOrderStatusTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private OrderService orderService;
+
+	@Nested
+	@DisplayName("주문 상태 변경 API [/customer/order/{orderId}/status] 테스트")
+	class UpdateOrderStatusTest {
+
+		@Test
+		@DisplayName("성공: 유효한 요청으로 주문 상태를 변경하면 200 OK와 변경된 상태 정보를 반환한다.")
+		void updateOrderStatus_Success() throws Exception {
+			// given
+			UUID orderId = UUID.randomUUID();
+			UpdateOrderStatusRequest request = new UpdateOrderStatusRequest();
+			request.setNewStatus(OrderStatus.ACCEPTED);
+
+			UpdateOrderStatusResponse mockResponse = UpdateOrderStatusResponse.builder()
+				.orderId(orderId)
+				.updatedStatus(OrderStatus.ACCEPTED)
+				.build();
+
+			given(orderService.updateOrderStatus(eq(orderId), eq(OrderStatus.ACCEPTED))).willReturn(mockResponse);
+
+			// when
+			ResultActions resultActions = mockMvc.perform(patch("/customer/order/{orderId}/status", orderId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)));
+
+			// then
+			resultActions
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.isSuccess").value(true))
+				.andExpect(jsonPath("$.code").value(OrderSuccessStatus.ORDER_STATUS_UPDATED.getCode()))
+				.andExpect(jsonPath("$.result.orderId").value(orderId.toString()))
+				.andExpect(jsonPath("$.result.updatedStatus").value("ACCEPTED"))
+				.andDo(print());
+		}
+
+		@Test
+		@DisplayName("실패(유효성 검증): 주문 상태(newStatus)가 누락된 요청은 400 Bad Request를 반환한다.")
+		void updateOrderStatus_Fail_Validation() throws Exception {
+			// given
+			UUID orderId = UUID.randomUUID();
+			UpdateOrderStatusRequest request = new UpdateOrderStatusRequest();
+			request.setNewStatus(null);
+
+			// when
+			ResultActions resultActions = mockMvc.perform(patch("/customer/order/{orderId}/status", orderId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)));
+
+			// then
+			resultActions
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.isSuccess").value(false))
+				.andExpect(jsonPath("$.code").value(ErrorStatus._BAD_REQUEST.getCode()))
+				.andExpect(jsonPath("$.result.newStatus").exists())
+				.andDo(print());
+		}
+
+		@Test
+		@DisplayName("실패(비즈니스 로직): 권한 없는 사용자가 요청 시 403 Forbidden을 반환한다.")
+		void updateOrderStatus_Fail_AccessDenied() throws Exception {
+			// given
+			UUID orderId = UUID.randomUUID();
+			UpdateOrderStatusRequest request = new UpdateOrderStatusRequest();
+			request.setNewStatus(OrderStatus.ACCEPTED);
+
+			given(orderService.updateOrderStatus(eq(orderId), any(OrderStatus.class)))
+				.willThrow(new GeneralException(OrderErrorStatus.ORDER_ACCESS_DENIED));
+
+			// when
+			ResultActions resultActions = mockMvc.perform(patch("/customer/order/{orderId}/status", orderId)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)));
+
+			// then
+			resultActions
+				.andExpect(status().isForbidden()) // 💡 HTTP 403 상태 코드를 기대
+				.andExpect(jsonPath("$.isSuccess").value(false))
+				.andExpect(jsonPath("$.code").value(OrderErrorStatus.ORDER_ACCESS_DENIED.getCode()))
+				.andDo(print());
+		}
+	}
+}

--- a/src/test/java/app/unit/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/app/unit/domain/user/controller/UserControllerTest.java
@@ -23,9 +23,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import app.domain.user.UserController;
 import app.domain.user.UserService;
 import app.domain.user.model.dto.request.CreateUserRequest;
+import app.domain.user.model.dto.request.LoginRequest;
 import app.domain.user.model.dto.response.CreateUserResponse;
+import app.domain.user.model.dto.response.GetUserInfoResponse;
+import app.domain.user.model.dto.response.LoginResponse;
 import app.domain.user.model.entity.enums.UserRole;
 import app.domain.user.status.UserErrorStatus;
+import app.domain.user.status.UserSuccessStatus;
+import app.global.apiPayload.code.status.ErrorStatus;
 import app.global.apiPayload.exception.GeneralException;
 import app.global.config.MockSecurityConfig;
 
@@ -53,6 +58,13 @@ class UserControllerTest {
 		req.setRealName("김테스트");
 		req.setPhoneNumber("01012345678");
 		req.setUserRole(role);
+		return req;
+	}
+
+	private LoginRequest createValidLoginReq() {
+		LoginRequest req = new LoginRequest();
+		req.setUsername("testuser");
+		req.setPassword("password123!");
 		return req;
 	}
 
@@ -131,4 +143,175 @@ class UserControllerTest {
 				.andDo(print());
 		}
 	}
+
+	@Nested
+	@DisplayName("로그인 API [/user/login] 테스트")
+	class LoginTest {
+
+		@Test
+		@DisplayName("성공: 올바른 아이디와 비밀번호로 로그인하면 200 OK와 토큰 정보를 반환한다.")
+		void login_Success() throws Exception {
+			// given
+			LoginRequest req = createValidLoginReq();
+			LoginResponse mockResponse = LoginResponse.builder()
+				.accessToken("dummy-access-token")
+				.refreshToken("dummy-refresh-token")
+				.build();
+			given(userService.login(any(LoginRequest.class))).willReturn(mockResponse);
+
+			// when
+			ResultActions resultActions = mockMvc.perform(post("/user/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(req)));
+
+			// then
+			resultActions
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.isSuccess").value(true))
+				.andExpect(jsonPath("$.code").value(UserSuccessStatus.LOGIN_SUCCESS.getCode()))
+				.andExpect(jsonPath("$.result.accessToken").value(mockResponse.getAccessToken()))
+				.andDo(print());
+		}
+
+		@Test
+		@DisplayName("실패(유효성 검증): 비밀번호가 누락된 요청은 400 Bad Request를 반환한다.")
+		void login_Fail_Validation() throws Exception {
+			// given
+			LoginRequest req = createValidLoginReq();
+			req.setPassword(null); // 유효하지 않은 값
+
+			// when
+			ResultActions resultActions = mockMvc.perform(post("/user/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(req)));
+
+			// then
+			resultActions
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.isSuccess").value(false))
+				.andExpect(jsonPath("$.code").value(ErrorStatus._BAD_REQUEST.getCode()))
+				.andExpect(jsonPath("$.result.password").exists())
+				.andDo(print());
+		}
+
+		@Test
+		@DisplayName("실패(비즈니스 로직): 존재하지 않는 사용자로 로그인을 요청하면 404 Not Found를 반환한다.")
+		void login_Fail_UserNotFound() throws Exception {
+			// given
+			LoginRequest req = createValidLoginReq();
+			given(userService.login(any(LoginRequest.class)))
+				.willThrow(new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+			// when
+			ResultActions resultActions = mockMvc.perform(post("/user/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(req)));
+
+			// then
+			resultActions
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.isSuccess").value(false))
+				.andExpect(jsonPath("$.code").value(ErrorStatus.USER_NOT_FOUND.getCode()))
+				.andDo(print());
+		}
+	}
+
+	@Nested
+	@DisplayName("로그아웃 API [/user/logout] 테스트")
+	class LogoutTest {
+
+		@Test
+		@DisplayName("성공: 로그아웃 요청 시 200 OK를 반환한다.")
+		void logout_Success() throws Exception {
+			// given
+			// userService.logout()은 반환값이 없으므로, 예외가 발생하지 않도록 설정
+			willDoNothing().given(userService).logout();
+
+			// when
+			ResultActions resultActions = mockMvc.perform(post("/user/logout"));
+
+			// then
+			resultActions
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.isSuccess").value(true))
+				.andExpect(jsonPath("$.code").value(UserSuccessStatus.LOGOUT_SUCCESS.getCode()))
+				.andDo(print());
+
+			// 서비스 메서드가 호출되었는지 검증
+			then(userService).should().logout();
+		}
+	}
+
+	@Nested
+	@DisplayName("회원 탈퇴 API [/user/withdraw] 테스트")
+	class WithdrawTest {
+
+		@Test
+		@DisplayName("성공: 회원 탈퇴 요청 시 200 OK를 반환한다.")
+		void withdraw_Success() throws Exception {
+			// given
+			willDoNothing().given(userService).withdrawMembership();
+
+			// when
+			ResultActions resultActions = mockMvc.perform(delete("/user/withdraw"));
+
+			// then
+			resultActions
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.isSuccess").value(true))
+				.andExpect(jsonPath("$.code").value(UserSuccessStatus.WITHDRAW_SUCCESS.getCode()))
+				.andDo(print());
+
+			// 서비스 메서드가 호출되었는지 검증
+			then(userService).should().withdrawMembership();
+		}
+	}
+
+	@Nested
+	@DisplayName("회원 정보 조회 API [/user/info] 테스트")
+	class GetUserInfoTest {
+
+		@Test
+		@DisplayName("성공: 회원 정보 조회 요청 시 200 OK와 사용자 정보를 반환한다.")
+		void getUserInfo_Success() throws Exception {
+			// given
+			GetUserInfoResponse mockResponse = GetUserInfoResponse.builder()
+				.userId(1L)
+				.username("testuser")
+				.email("test@example.com")
+				.build();
+			given(userService.getUserInfo()).willReturn(mockResponse);
+
+			// when
+			ResultActions resultActions = mockMvc.perform(get("/user/info"));
+
+			// then
+			resultActions
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.isSuccess").value(true))
+				.andExpect(jsonPath("$.code").value(UserSuccessStatus.USER_PROFILE_FETCHED.getCode()))
+				.andExpect(jsonPath("$.result.userId").value(mockResponse.getUserId()))
+				.andExpect(jsonPath("$.result.username").value(mockResponse.getUsername()))
+				.andDo(print());
+		}
+
+		@Test
+		@DisplayName("실패(비즈니스 로직): 인증 정보가 없는 상태로 요청 시 401 Unauthorized를 반환한다.")
+		void getUserInfo_Fail_Unauthorized() throws Exception {
+			// given
+			given(userService.getUserInfo())
+				.willThrow(new GeneralException(ErrorStatus._UNAUTHORIZED));
+
+			// when
+			ResultActions resultActions = mockMvc.perform(get("/user/info"));
+
+			// then
+			resultActions
+				.andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.isSuccess").value(false))
+				.andExpect(jsonPath("$.code").value(ErrorStatus._UNAUTHORIZED.getCode()))
+				.andDo(print());
+		}
+	}
+
 }

--- a/src/test/java/app/unit/domain/user/model/UserRepositoryCustomTest.java
+++ b/src/test/java/app/unit/domain/user/model/UserRepositoryCustomTest.java
@@ -1,0 +1,129 @@
+package app.unit.domain.user.model;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import app.domain.user.model.UserRepository;
+import app.domain.user.model.entity.User;
+import app.domain.user.model.entity.enums.UserRole;
+import app.global.config.QueryDslConfig;
+import app.global.config.TestJpaConfig;
+
+@DataJpaTest
+@Import({QueryDslConfig.class, TestJpaConfig.class})
+@DisplayName("UserRepository 테스트")
+class UserRepositoryDslTest {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	private User existingUser;
+
+	@BeforeEach
+	void setUp() {
+		userRepository.deleteAllInBatch();
+
+		existingUser = User.builder()
+			.username("testuser")
+			.password("password")
+			.email("test@example.com")
+			.nickname("testnick")
+			.realName("테스트유저")
+			.phoneNumber("01012345678")
+			.userRole(UserRole.CUSTOMER)
+			.build();
+		userRepository.save(existingUser);
+	}
+
+	@Nested
+	@DisplayName("findFirstByUniqueFields 메서드")
+	class FindFirstByUniqueFieldsTest {
+
+		@Test
+		@DisplayName("성공: 중복된 username으로 사용자를 조회한다")
+		void findByUsername_Success() {
+			// when
+			Optional<User> foundUser = userRepository.findFirstByUniqueFields(
+				"testuser", "new@email.com", "new_nick", "01099998888");
+
+			// then
+			assertThat(foundUser).isPresent();
+			assertThat(foundUser.get().getUsername()).isEqualTo(existingUser.getUsername());
+		}
+
+		@Test
+		@DisplayName("성공: 중복된 email로 사용자를 조회한다")
+		void findByEmail_Success() {
+			// when
+			Optional<User> foundUser = userRepository.findFirstByUniqueFields(
+				"new_user", "test@example.com", "new_nick", "01099998888");
+
+			// then
+			assertThat(foundUser).isPresent();
+			assertThat(foundUser.get().getEmail()).isEqualTo(existingUser.getEmail());
+		}
+
+		@Test
+		@DisplayName("성공: 중복된 nickname으로 사용자를 조회한다")
+		void findByNickname_Success() {
+			// when
+			Optional<User> foundUser = userRepository.findFirstByUniqueFields(
+				"new_user", "new@email.com", "testnick", "01099998888");
+
+			// then
+			assertThat(foundUser).isPresent();
+			assertThat(foundUser.get().getNickname()).isEqualTo(existingUser.getNickname());
+		}
+
+		@Test
+		@DisplayName("성공: 중복된 phoneNumber로 사용자를 조회한다")
+		void findByPhoneNumber_Success() {
+			// when
+			Optional<User> foundUser = userRepository.findFirstByUniqueFields(
+				"new_user", "new@email.com", "new_nick", "01012345678");
+
+			// then
+			assertThat(foundUser).isPresent();
+			assertThat(foundUser.get().getPhoneNumber()).isEqualTo(existingUser.getPhoneNumber());
+		}
+
+		@Test
+		@DisplayName("실패: 중복된 필드가 하나도 없을 경우, 빈 Optional을 반환한다")
+		void findWithNoDuplicates_ShouldReturnEmpty() {
+			// when
+			Optional<User> foundUser = userRepository.findFirstByUniqueFields(
+				"new_user", "new@email.com", "new_nick", "01099998888");
+
+			// then
+			assertThat(foundUser).isNotPresent();
+		}
+
+		@Test
+		@DisplayName("성공: 여러 필드가 중복될 경우에도 사용자를 조회한다 (OR 조건 테스트)")
+		void findWithMultipleDuplicates_ShouldReturnUser() {
+			// given
+			String duplicateUsername = "testuser";
+			String newEmail = "new@email.com";
+			String newNickname = "new_nick";
+			String duplicatePhoneNumber = "01012345678";
+
+			// when
+			Optional<User> foundUser = userRepository.findFirstByUniqueFields(
+				duplicateUsername, newEmail, newNickname, duplicatePhoneNumber
+			);
+
+			// then
+			assertThat(foundUser).isPresent();
+			assertThat(foundUser.get().getUserId()).isEqualTo(existingUser.getUserId());
+		}
+	}
+}

--- a/src/test/java/app/unit/domain/user/service/UserServiceGetUserInfoTest.java
+++ b/src/test/java/app/unit/domain/user/service/UserServiceGetUserInfoTest.java
@@ -1,4 +1,4 @@
-package app.domain.user;
+package app.unit.domain.user.service;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataAccessException;
 
+import app.domain.user.UserService;
 import app.domain.user.model.dto.response.GetUserInfoResponse;
 import app.domain.user.model.entity.User;
 import app.domain.user.model.entity.enums.UserRole;

--- a/src/test/java/app/unit/domain/user/service/UserServiceLoginTest.java
+++ b/src/test/java/app/unit/domain/user/service/UserServiceLoginTest.java
@@ -69,7 +69,6 @@ class UserServiceLoginTest {
 			// given
 			LoginRequest request = createLoginRequest("testuser", "password123!");
 			User mockUser = User.builder()
-				.userId(1L)
 				.username("testuser")
 				.password("encodedPassword")
 				.build();
@@ -102,7 +101,6 @@ class UserServiceLoginTest {
 				timeUnitCaptor.capture()
 			);
 
-			// [검증 강화] 캡처된 값들이 예상과 일치하는지 개별적으로 검증
 			assertThat(keyCaptor.getValue()).isEqualTo("RT:" + mockUser.getUserId());
 			assertThat(valueCaptor.getValue()).isEqualTo("dummy-refresh-token");
 			assertThat(timeoutCaptor.getValue()).isEqualTo(1209600000L);

--- a/src/test/java/app/unit/domain/user/service/UserServiceLogoutTest.java
+++ b/src/test/java/app/unit/domain/user/service/UserServiceLogoutTest.java
@@ -1,0 +1,170 @@
+package app.unit.domain.user.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import app.domain.user.UserService;
+import app.domain.user.status.UserErrorStatus;
+import app.global.apiPayload.exception.GeneralException;
+import app.global.jwt.JwtTokenProvider;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserService.logout 테스트")
+class UserServiceLogoutTest {
+
+	@InjectMocks
+	private UserService userService;
+
+	@Mock
+	private JwtTokenProvider jwtTokenProvider;
+
+	@Mock
+	private RedisTemplate<String, String> redisTemplate;
+
+	@Mock
+	private ValueOperations<String, String> valueOperations;
+
+	private MockedStatic<SecurityContextHolder> mockedSecurityContextHolder;
+
+	@Mock
+	private SecurityContext securityContext;
+
+	@Mock
+	private Authentication authentication;
+
+	@BeforeEach
+	void setUp() {
+		mockedSecurityContextHolder = Mockito.mockStatic(SecurityContextHolder.class);
+		given(SecurityContextHolder.getContext()).willReturn(securityContext);
+	}
+
+	@AfterEach
+	void tearDown() {
+		mockedSecurityContextHolder.close();
+	}
+
+	@Nested
+	@DisplayName("성공 케이스")
+	class SuccessCase {
+		@Test
+		@DisplayName("정상 로그아웃: RefreshToken을 삭제하고 유효한 AccessToken을 블랙리스트에 추가한다.")
+		void logout_Success_DeletesRefreshTokenAndBlacklistsAccessToken() {
+			// given
+			String userId = "1";
+			String accessToken = "valid-access-token";
+			String refreshTokenKey = "RT:" + userId;
+			long expiration = 1000L;
+
+			given(securityContext.getAuthentication()).willReturn(authentication);
+			given(authentication.getName()).willReturn(userId);
+			given(authentication.getCredentials()).willReturn(accessToken);
+			given(authentication.isAuthenticated()).willReturn(true);
+			given(redisTemplate.hasKey(refreshTokenKey)).willReturn(true);
+			given(jwtTokenProvider.getExpiration(accessToken)).willReturn(expiration);
+			given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+			// when
+			userService.logout();
+
+			// then
+			then(redisTemplate).should().delete(refreshTokenKey);
+			then(valueOperations).should().set(
+				"BL:" + accessToken,
+				"logout",
+				expiration,
+				TimeUnit.MILLISECONDS
+			);
+		}
+
+		@Test
+		@DisplayName("RefreshToken이 없어도 AccessToken을 블랙리스트에 추가하며 정상 처리된다.")
+		void logout_Success_WhenRefreshTokenNotExists() {
+			// given
+			String userId = "1";
+			String accessToken = "valid-access-token";
+			String refreshTokenKey = "RT:" + userId;
+			long expiration = 1000L;
+
+			given(securityContext.getAuthentication()).willReturn(authentication);
+			given(authentication.getName()).willReturn(userId);
+			given(authentication.getCredentials()).willReturn(accessToken);
+			given(authentication.isAuthenticated()).willReturn(true);
+			given(redisTemplate.hasKey(refreshTokenKey)).willReturn(false);
+			given(jwtTokenProvider.getExpiration(accessToken)).willReturn(expiration);
+			given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+			// when
+			userService.logout();
+
+			// then
+			then(redisTemplate).should(never()).delete(refreshTokenKey);
+			then(valueOperations).should().set(
+				"BL:" + accessToken,
+				"logout",
+				expiration,
+				TimeUnit.MILLISECONDS
+			);
+		}
+
+		@Test
+		@DisplayName("AccessToken이 이미 만료된 경우, RefreshToken만 삭제하고 블랙리스트에는 추가하지 않는다.")
+		void logout_Success_WhenAccessTokenIsExpired() {
+			// given
+			String userId = "1";
+			String accessToken = "expired-access-token";
+			String refreshTokenKey = "RT:" + userId;
+			long expiration = 0L;
+
+			given(securityContext.getAuthentication()).willReturn(authentication);
+			given(authentication.getName()).willReturn(userId);
+			given(authentication.getCredentials()).willReturn(accessToken);
+			given(authentication.isAuthenticated()).willReturn(true);
+			given(redisTemplate.hasKey(refreshTokenKey)).willReturn(true);
+			given(jwtTokenProvider.getExpiration(accessToken)).willReturn(expiration);
+
+			// when
+			userService.logout();
+
+			// then
+			then(redisTemplate).should().delete(refreshTokenKey);
+			then(redisTemplate).should(never()).opsForValue();
+		}
+	}
+
+	@Nested
+	@DisplayName("실패 케이스")
+	class FailureCase {
+
+		@Test
+		@DisplayName("인증 객체가 없는 경우(비로그인 상태), AUTHENTICATION_NOT_FOUND 예외를 던진다.")
+		void logout_Fail_WhenAuthenticationIsNull() {
+			// given
+			given(securityContext.getAuthentication()).willReturn(null);
+
+			// when & then
+			assertThatThrownBy(() -> userService.logout())
+				.isInstanceOf(GeneralException.class)
+				.extracting("code")
+				.isEqualTo(UserErrorStatus.AUTHENTICATION_NOT_FOUND);
+		}
+	}
+}

--- a/src/test/java/app/unit/domain/user/service/UserServiceWithdrawMembershipTest.java
+++ b/src/test/java/app/unit/domain/user/service/UserServiceWithdrawMembershipTest.java
@@ -1,0 +1,132 @@
+package app.unit.domain.user.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataAccessException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import app.domain.user.UserService;
+import app.domain.user.model.UserRepository;
+import app.domain.user.model.entity.User;
+import app.global.apiPayload.code.status.ErrorStatus;
+import app.global.apiPayload.exception.GeneralException;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserService.withdrawMembership 테스트")
+class UserServiceWithdrawMembershipTest {
+
+	@Spy
+	@InjectMocks
+	private UserService userService;
+
+	@Mock
+	private UserRepository userRepository;
+
+	private MockedStatic<SecurityContextHolder> mockedSecurityContextHolder;
+
+	@Mock
+	private SecurityContext securityContext;
+
+	@Mock
+	private Authentication authentication;
+
+	@BeforeEach
+	void setUp() {
+		mockedSecurityContextHolder = Mockito.mockStatic(SecurityContextHolder.class);
+		given(SecurityContextHolder.getContext()).willReturn(securityContext);
+		given(securityContext.getAuthentication()).willReturn(authentication);
+	}
+
+	@AfterEach
+	void tearDown() {
+		mockedSecurityContextHolder.close();
+	}
+
+	@Nested
+	@DisplayName("성공 케이스")
+	class SuccessCase {
+
+		@Test
+		@DisplayName("정상적으로 회원 탈퇴를 처리하고 로그아웃을 호출한다.")
+		void withdrawMembership_Success() {
+			// given
+			Long userId = 1L;
+			User userToWithdraw = spy(User.builder().userId(userId).build());
+
+			given(authentication.getName()).willReturn(String.valueOf(userId));
+			given(userRepository.findById(userId)).willReturn(Optional.of(userToWithdraw));
+			willDoNothing().given(userRepository).delete(any(User.class));
+			willDoNothing().given(userService).logout();
+
+			// when
+			userService.withdrawMembership();
+
+			// then
+			then(userRepository).should().findById(userId);
+			then(userToWithdraw).should().anonymizeForWithdrawal();
+			then(userRepository).should().delete(userToWithdraw);
+			then(userService).should().logout();
+		}
+	}
+
+	@Nested
+	@DisplayName("실패 케이스")
+	class FailureCase {
+
+		@Test
+		@DisplayName("존재하지 않는 사용자로 탈퇴 시도 시 USER_NOT_FOUND 예외가 발생한다.")
+		void withdrawMembership_UserNotFound_ThrowsException() {
+			// given
+			Long userId = 99L;
+			given(authentication.getName()).willReturn(String.valueOf(userId));
+			given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+			// when & then
+			assertThatThrownBy(() -> userService.withdrawMembership())
+				.isInstanceOf(GeneralException.class)
+				.extracting("code")
+				.isEqualTo(ErrorStatus.USER_NOT_FOUND);
+
+			then(userRepository).should(never()).delete(any(User.class));
+			then(userService).should(never()).logout();
+		}
+
+		@Test
+		@DisplayName("DB에서 사용자 삭제 실패 시, 예외가 발생하고 로그아웃은 호출되지 않는다.")
+		void withdrawMembership_DeleteFails_ThrowsExceptionAndDoesNotLogout() {
+			// given
+			Long userId = 1L;
+			User userToWithdraw = spy(User.builder().userId(userId).build());
+
+			given(authentication.getName()).willReturn(String.valueOf(userId));
+			given(userRepository.findById(userId)).willReturn(Optional.of(userToWithdraw));
+			willThrow(new DataAccessException("DB delete failed") {
+			}).given(userRepository).delete(userToWithdraw);
+
+			// when & then
+			assertThatThrownBy(() -> userService.withdrawMembership())
+				.isInstanceOf(DataAccessException.class);
+
+			then(userToWithdraw).should().anonymizeForWithdrawal();
+			then(userRepository).should().delete(userToWithdraw);
+			then(userService).should(never()).logout();
+		}
+	}
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true


### PR DESCRIPTION
## 🔥 Related Issues

- close #82 

## 👍 작업 내용

- [x] ~ 테스트 코드 작성(controller, service, repository)
- [x] ~ 회원 정보 조회 기능 구현
- [x] ~ 회원가입 전 중복 필드 검사에 queryDSL로 변경

## ✅ PR Point

- queryDSL로 변경하면서 custom, customImpl 추가
- 테스트 코드(orderStatus, user 관련)